### PR TITLE
Post Schema Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A collection of extensions and helpers for working with Core Data.
 
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Frichardpiazza%2FCoreDataPlus%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/richardpiazza/CoreDataPlus)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Frichardpiazza%2FCoreDataPlus%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/richardpiazza/CoreDataPlus)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Frichardpiazza%2FCoreDataPlus%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/richardpiazza/CoreDataPlus)
 
 ## Usage
 

--- a/Sources/CoreDataPlus/Extensions/NSPersistentContainer+CoreDataPlus.swift
+++ b/Sources/CoreDataPlus/Extensions/NSPersistentContainer+CoreDataPlus.swift
@@ -3,6 +3,61 @@ import Foundation
 import CoreData
 
 public extension NSPersistentContainer {
+    convenience init(
+        name: String,
+        version: ModelVersion,
+        persistence: Persistence
+    ) throws {
+        self.init(
+            name: name,
+            managedObjectModel: version.managedObjectModel
+        )
+        
+        let description = NSPersistentStoreDescription()
+        description.shouldInferMappingModelAutomatically = false
+        description.shouldMigrateStoreAutomatically = false
+        switch persistence {
+        case .store(let storeURL):
+            description.type = storeURL.storeType
+            description.url = storeURL.rawValue
+        case .memory:
+            description.type = NSInMemoryStoreType
+        }
+        
+        persistentStoreDescriptions = [description]
+        
+        var loadError: Error? = nil
+        // `loadPersistentStores` seems like it should be an asynchronous call, but…
+        // see `NSPersistentStoreDescription.shouldAddStoreAsynchronously`.
+        loadPersistentStores { (_, error) in
+            loadError = error
+        }
+        
+        if let error = loadError {
+            throw error
+        }
+        
+        viewContext.automaticallyMergesChangesFromParent = true
+        viewContext.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
+        viewContext.undoManager = nil
+    }
+    
+    /// Causes the write-ahead log to be integrated into the primary sqlite table.
+    ///
+    /// **WARNING**: The persistent container stores will be re-added, and all existing object references will become invalid.
+    func checkpointAndContinue() throws {
+        try checkpoint(reopen: true)
+        let context = viewContext
+        context.performAndWait {
+            context.refreshAllObjects()
+        }
+    }
+    
+    /// Causes the write-ahead log to be integrated into the primary sqlite table.
+    func checkpointAndClose() throws {
+        try checkpoint(reopen: false)
+    }
+    
     @discardableResult func loadPersistentStores() async throws -> [NSPersistentStoreDescription] {
         let count = persistentStoreDescriptions.count
         guard count > 0 else {
@@ -32,6 +87,52 @@ public extension NSPersistentContainer {
                         resumed = true
                     }
                 }
+            }
+        }
+    }
+}
+
+extension NSPersistentContainer {
+    func checkpoint(reopen: Bool) throws {
+        for description in persistentStoreDescriptions {
+            guard description.type == NSSQLiteStoreType else {
+                continue
+            }
+            
+            guard let url = description.url else {
+                continue
+            }
+            
+            let context = viewContext
+            if context.hasChanges {
+                try context.performAndWait {
+                    try context.save()
+                }
+            }
+            
+            let stores = persistentStoreCoordinator.persistentStores
+            for store in stores {
+                try persistentStoreCoordinator.remove(store)
+            }
+            
+            try NSPersistentStoreCoordinator.checkpoint(
+                storeAtURL: url,
+                model: managedObjectModel,
+                name: name
+            )
+            
+            guard reopen else {
+                continue
+            }
+            
+            // Similar to loadPersistentStores ?
+            var addError: Error? = nil
+            persistentStoreCoordinator.addPersistentStore(with: description) { _, error in
+                addError = error
+            }
+            
+            if let addError {
+                throw addError
             }
         }
     }


### PR DESCRIPTION
Adds an optional handler to perform operations on data after a specific schema version has been applied.
This can be used to ensure that data is consistent with the new schema before future access or migration steps are performed.